### PR TITLE
serial_puti: "i" may be used without initialization

### DIFF
--- a/src/serial.c
+++ b/src/serial.c
@@ -119,7 +119,7 @@ void serial_puti(unsigned int value)
 		}
 	} else {
 		message[0] = 0;
-		i++;
+		i = 1;
 	}
 
 	for (; i; i--)


### PR DESCRIPTION
Increment of uninitialized variable `i` in `serial_puti()`, assume it
must be `1` in case of `!value`.

Signed-off-by: Siarhei Volkau <lis8215@gmail.com>