### PR TITLE
lepus: revert to CL=4

### DIFF
--- a/src/DDR2_H5PS1G63EFR-S6C.h
+++ b/src/DDR2_H5PS1G63EFR-S6C.h
@@ -16,7 +16,7 @@
 #define DDR_ROW   13 /* ROW : 12 to 14 row address */
 #define DDR_COL   10 /* COL :  8 to 10 column address */
 #define DDR_BANK8  1 /* Banks each chip: 0-4bank, 1-8bank */
-#define DDR_CL     3 /* CAS latency: 1 to 6 */
+#define DDR_CL     4 /* CAS latency: 1 to 6 */
 
 /*
  * DDR2 controller timing1 register, unit: ps


### PR DESCRIPTION
CL=3 while providing a small performance boost, introduces a bug in the hashes calculations on lepus (and possibly more undiscovered problems)

Reverting to CL=4 fixes it.

Signed-off-by: Christophe Branchereau <cbranchereau@gmail.com>