### PR TITLE
Remove MBR_PRELOAD_ADDR

### DIFF
--- a/src/config-gcw0.h
+++ b/src/config-gcw0.h
@@ -7,8 +7,6 @@
 #define CFG_CPU_SPEED		996000000
 #define CFG_EXTAL			12000000
 
-#define MBR_PRELOAD_ADDR	0x80000000
-
 #define USES_HIGHMEM
 
 /* serial parameters */

--- a/src/config-lepus.h
+++ b/src/config-lepus.h
@@ -11,8 +11,6 @@
 
 #define CFG_EXTAL		12000000
 
-#define MBR_PRELOAD_ADDR	0x80000000
-
 #define RFKILL_STATE		0
 
 //#define USES_HIGHMEM

--- a/src/fat.c
+++ b/src/fat.c
@@ -18,9 +18,6 @@ uint8_t cluster_size;		/* sectors per cluster */
 
 static int get_first_partition(unsigned int id, uint32_t *lba)
 {
-#if defined(MBR_PRELOAD_ADDR) && !defined(STAGE1_ONLY)
-	struct mbr *mbr = (struct mbr *) MBR_PRELOAD_ADDR;
-#else
 	uint8_t mbr_data[MMC_SECTOR_SIZE];
 	struct mbr *mbr = (struct mbr *) &mbr_data;
 
@@ -28,7 +25,6 @@ static int get_first_partition(unsigned int id, uint32_t *lba)
 		SERIAL_ERR(ERR_FAT_IO_BOOT);
 		return -1;
 	}
-#endif
 
 	if (mbr->signature != 0xAA55) {
 		SERIAL_ERR(ERR_FAT_NO_MBR);


### PR DESCRIPTION
Rely on the logic that UBIBoot loaded into RAM with MBR is broken. Because of full UBiboot might be loaded over USB now - jzboot patched to do so.

Another issue introduced by MBR_PRELOAD_ADDR is that it prevents to load real MBR for external MMC (e.g. MMC2 on lepus) and uses same preloaded MBR for it.

Closes #11